### PR TITLE
修改几处在开源版本MySQL模式下运行错误的问题

### DIFF
--- a/sample-dbs/tpcc/ob_mysql/create_mysql_sample.sql
+++ b/sample-dbs/tpcc/ob_mysql/create_mysql_sample.sql
@@ -1,7 +1,7 @@
 -- run as user 'root' in the tenant of type mysql
 source create_mysql_db.sql
 
-conn tpccdb
+use tpccdb
 source create_mysql_tables.sql
 source init_data.sql
 

--- a/sample-dbs/tpcc/ob_mysql/create_mysql_tables.sql
+++ b/sample-dbs/tpcc/ob_mysql/create_mysql_tables.sql
@@ -30,9 +30,10 @@ create table dist (d_w_id int
 create table cust (c_w_id int not null
 , c_d_id int not null
 , c_id int not null
-, c_discount decimal(4, 4) not null default 1.0 
+, c_discount decimal(4, 4) not null default 0.0 
 , c_credit char(2)
 , c_last varchar(16) not null
+, c_first varchar(16) not null
 , c_middle char(2) not null
 , c_balance decimal(12, 2)
 , c_ytd_payment decimal(12, 2)
@@ -112,8 +113,7 @@ create table stok (s_i_id int
 , s_dist_09 char(24)
 , s_dist_10 char(24)
 , primary key (s_i_id, s_w_id))tablegroup tpcc_group   USE_BLOOM_FILTER = TRUE 
-partition by hash(s_w_id) partitions 6 
-partition by column((s_i_id, s_w_id, s_order_cnt, s_ytd, s_remote_cnt, s_quantity));
+partition by hash(s_w_id) partitions 6; 
 create table load_hist(
 total_w_cnt int,
 min_w_id int,


### PR DESCRIPTION
1. create mysql sample 文件中使用conn切换数据库报错，更改为use切换；
2. create mysql tables 文件中第一个报错【ERROR 1067 (42000) at line 30 in file: 'create_mysql_tables.sql': Invalid default value for 'c_discount' 】，查看对应的insert语句，插入的均为0.xxxx值，所以更改为default 0.0；
3. create mysql tables 文件中第二个报错【ERROR 1072 (42000) at line 30 in file: 'create_mysql_tables.sql': Key column 'c_first' doesn't exist in table】，少一列，查看insert，猜测应该与c_last类型一致，所以增加该列；
4. create mysql tables 文件中第三个报错 ERROR 1235 (0A000) at line 97 in file: 'create_mysql_tables.sql': Not supported feature or function】，猜测是复制错了？所以把多余的partition by column部分删掉了。
